### PR TITLE
Fix can't open database problem

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,8 +3,10 @@
 // found in the LICENSE file.
 
 import 'package:flutter/widgets.dart';
-import 'package:sqflite/sqflite.dart';
 import 'package:jaguar_query_sqflite/jaguar_query_sqflite.dart';
+import 'package:path/path.dart' as path;
+import 'package:sqflite/sqflite.dart';
+
 import 'post.dart';
 
 /// The adapter
@@ -16,7 +18,8 @@ void main() async {
 
   sb.writeln('--------------');
   sb.write('Connecting ...');
-  _adapter = new SqfliteAdapter(await getDatabasesPath());
+  var dbPath = await getDatabasesPath();
+  _adapter = new SqfliteAdapter(path.join(dbPath, "test.db"));
   await _adapter.connect();
   sb.writeln(' successful!');
   sb.writeln('--------------');


### PR DESCRIPTION
The example didn't work for me without this fix :) 
Worked on iOS and Android after.

I had other problems with dependencies also, didn't work directly, I didn't push my changes put here is my pubspec
```
name: sqflite_example

dependencies:
  flutter:
    sdk: flutter

  sqflite:
  jaguar_query_sqflite: ^2.1.5

dev_dependencies:
  flutter_test:
    sdk: flutter

  jaguar_orm_gen: ^2.1.5
  build_runner: ^0.8.9

  analyzer: 0.31.2-alpha.2 #force version to be able to override it
  path: 1.6.1 #force version to be able to override it

flutter:
  uses-material-design: true

dependency_overrides:
  analyzer: ^0.31.0
  path: 1.6.0
# PUBSPEC CHECKSUM: e214
```